### PR TITLE
Fix prediction field naming and parsing

### DIFF
--- a/src/components/AIChatInterface.tsx
+++ b/src/components/AIChatInterface.tsx
@@ -223,7 +223,7 @@ export const AIChatInterface = ({ reports }: AIChatInterfaceProps) => {
       ],
       predictions: {
         efficiencyImprovement: '10-15%',
-        savingsPotential: '20-25%'
+        potentialSavings: '20-25%'
       },
       confidence: 0.80,
       model: 'local-analysis'

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -127,11 +127,27 @@ class AIService {
   }
 
   private extractPredictions(content: string): any {
-    const predictions = content.match(/predictions?[:\s]+(.*?)(?=\n|$)/gi);
-    return {
+    const match = content.match(/predictions?[:\s]+(.*?)(?=\n|$)/i);
+    const defaults = {
       costTrend: 'stable',
       efficiencyImprovement: '5-10%',
-      savingsPotential: '15-20%'
+      potentialSavings: '15-20%'
+    };
+
+    if (!match) {
+      return defaults;
+    }
+
+    const text = match[1];
+
+    const costTrendMatch = text.match(/cost(?:\s+trend)?[:\s]+([^;,.]+)/i);
+    const efficiencyMatch = text.match(/efficiency(?:\s+improvement)?[:\s]+([^;,.]+)/i);
+    const savingsMatch = text.match(/(?:potential\s+)?savings?[:\s]+([^;,.]+)/i);
+
+    return {
+      costTrend: costTrendMatch ? costTrendMatch[1].trim() : defaults.costTrend,
+      efficiencyImprovement: efficiencyMatch ? efficiencyMatch[1].trim() : defaults.efficiencyImprovement,
+      potentialSavings: savingsMatch ? savingsMatch[1].trim() : defaults.potentialSavings
     };
   }
 
@@ -150,7 +166,7 @@ class AIService {
       predictions: {
         costTrend: 'stable',
         efficiencyImprovement: '5-10%',
-        savingsPotential: '15-20%'
+        potentialSavings: '15-20%'
       },
       confidence: 0.75,
       model: 'local-fallback'


### PR DESCRIPTION
## Summary
- parse prediction text to extract cost trend, efficiency improvement, and potential savings
- use `potentialSavings` key consistently across AI services and chat interface

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: @typescript-eslint/no-explicit-any)


------
https://chatgpt.com/codex/tasks/task_e_68b882e00fec83339be83b5c76f8ad43