### PR TITLE
feat: add delete confirmation to report history

### DIFF
--- a/src/components/ReportsHistory.tsx
+++ b/src/components/ReportsHistory.tsx
@@ -155,7 +155,11 @@ export const ReportsHistory = ({ reports, onViewReport, onEditReport, onDeleteRe
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => onDeleteReport(report.id)}
+                      onClick={() => {
+                        if (window.confirm("Are you sure you want to delete this report?")) {
+                          onDeleteReport(report.id);
+                        }
+                      }}
                       className="flex items-center justify-center gap-2 h-9 text-destructive hover:text-destructive hover:bg-destructive/10"
                     >
                       <Trash2 className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- prompt user to confirm before deleting reports

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any, specify different type)


------
https://chatgpt.com/codex/tasks/task_e_68b8856bbf7883339ebde8d2bed53381